### PR TITLE
Give Informative Error Msg when FaeServer is Given Unrecognised Args.

### DIFF
--- a/bin/FaeServer.hs
+++ b/bin/FaeServer.hs
@@ -30,6 +30,8 @@ import Control.Monad
 import Control.Monad.Reader
 import Control.Monad.Trans
 
+import Control.Exception (throw)
+
 import Data.Maybe
 
 import FaeServer.App
@@ -61,4 +63,4 @@ main = do
     case args of
       [] -> runFaeServer queueTXExecData 
       ["--faeth"] -> runFaeth tID
-
+      a -> error $ "Unrecognized arg(s) " ++ (concat a) ++ " passed to faeServer"


### PR DESCRIPTION
Before non-exhaustive pattern match error was propagated directly to the user when an unexpected argument was passed with the call to run faeServer. This change leads to a more informative error.